### PR TITLE
Upgrade version of dd-trace-php

### DIFF
--- a/php-7.3/Dockerfile
+++ b/php-7.3/Dockerfile
@@ -133,10 +133,10 @@ ENTRYPOINT ["entrypoint.sh"]
 
 # Add Datadog to the Phalcon + New Relic image
 FROM php-7.3-phalcon-newrelic AS php-7.3-phalcon-newrelic-datadog
-RUN curl -SsLo datadog-php-tracer.deb https://github.com/DataDog/dd-trace-php/releases/download/0.48.3/datadog-php-tracer_0.48.3_amd64.deb \
+RUN curl -SsLo datadog-php-tracer.deb https://github.com/DataDog/dd-trace-php/releases/download/0.51.0/datadog-php-tracer_0.51.0_amd64.deb \
     && dpkg -i datadog-php-tracer.deb
 
 # Add Datadog to the base New Relic image
 FROM php-7.3-newrelic AS php-7.3-newrelic-datadog
-RUN curl -SsLo datadog-php-tracer.deb https://github.com/DataDog/dd-trace-php/releases/download/0.48.3/datadog-php-tracer_0.48.3_amd64.deb \
+RUN curl -SsLo datadog-php-tracer.deb https://github.com/DataDog/dd-trace-php/releases/download/0.51.0/datadog-php-tracer_0.51.0_amd64.deb \
     && dpkg -i datadog-php-tracer.deb

--- a/php-7.4/Dockerfile
+++ b/php-7.4/Dockerfile
@@ -103,5 +103,5 @@ ENTRYPOINT ["entrypoint.sh"]
 
 # Datadog build stage
 FROM php-7.4-newrelic AS php-7.4-newrelic-datadog
-RUN curl -SsLo datadog-php-tracer.deb https://github.com/DataDog/dd-trace-php/releases/download/0.48.3/datadog-php-tracer_0.48.3_amd64.deb \
+RUN curl -SsLo datadog-php-tracer.deb https://github.com/DataDog/dd-trace-php/releases/download/0.51.0/datadog-php-tracer_0.51.0_amd64.deb \
     && dpkg -i datadog-php-tracer.deb


### PR DESCRIPTION
## Changes
- Images for 7.3 and 7.4 now have the newest version of `dd-trace-php`, which fixes a critical bug. 

## JIRA Ticket
- [IM-185](https://55places.atlassian.net/browse/IM-202)